### PR TITLE
Potential fix for code scanning alert no. 3632: Cross-site scripting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -608,6 +608,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.13.0</version>
+        </dependency>
+        <dependency>
             <groupId>javax</groupId>
             <artifactId>javaee-api</artifactId>
             <version>8.0.1</version>

--- a/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02718.java
+++ b/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02718.java
@@ -18,6 +18,7 @@
 package org.owasp.benchmark.testcode;
 
 import java.io.IOException;
+import org.apache.commons.text.StringEscapeUtils;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -75,7 +76,7 @@ public class BenchmarkTest02718 extends HttpServlet {
             }
 
             if (foundUser) {
-                response.getWriter().println("Welcome back: " + user + "<br/>");
+                response.getWriter().println("Welcome back: " + org.apache.commons.text.StringEscapeUtils.escapeHtml4(user) + "<br/>");
             } else {
                 javax.servlet.http.Cookie rememberMe =
                         new javax.servlet.http.Cookie(cookieName, rememberMeKey);
@@ -87,11 +88,11 @@ public class BenchmarkTest02718 extends HttpServlet {
                 response.addCookie(rememberMe);
                 response.getWriter()
                         .println(
-                                user
+                                org.apache.commons.text.StringEscapeUtils.escapeHtml4(user)
                                         + " has been remembered with cookie: "
                                         + rememberMe.getName()
                                         + " whose value is: "
-                                        + rememberMe.getValue()
+                                        + org.apache.commons.text.StringEscapeUtils.escapeHtml4(rememberMe.getValue())
                                         + "<br/>");
             }
         } catch (java.security.NoSuchAlgorithmException e) {


### PR DESCRIPTION
Potential fix for [https://github.com/GrepSecurity/project-ignore-java-2/security/code-scanning/3632](https://github.com/GrepSecurity/project-ignore-java-2/security/code-scanning/3632)

To fix the cross-site scripting vulnerability, we need to ensure that any user-controlled data is properly sanitized or encoded before being written to the response. In this case, we should encode the `user` and `rememberMe.getValue()` values before including them in the response. We can use the `StringEscapeUtils.escapeHtml4` method from the Apache Commons Text library to encode these values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
