### PR TITLE
Potential fix for code scanning alert no. 3628: Cross-site scripting

### DIFF
--- a/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02708.java
+++ b/src/main/java/org/owasp/benchmark/testcode/BenchmarkTest02708.java
@@ -72,7 +72,7 @@ public class BenchmarkTest02708 extends HttpServlet {
         }
 
         if (foundUser) {
-            response.getWriter().println("Welcome back: " + user + "<br/>");
+            response.getWriter().println("Welcome back: " + org.springframework.web.util.HtmlUtils.htmlEscape(user) + "<br/>");
 
         } else {
             javax.servlet.http.Cookie rememberMe =
@@ -85,11 +85,11 @@ public class BenchmarkTest02708 extends HttpServlet {
             response.addCookie(rememberMe);
             response.getWriter()
                     .println(
-                            user
+                            org.springframework.web.util.HtmlUtils.htmlEscape(user)
                                     + " has been remembered with cookie: "
-                                    + rememberMe.getName()
+                                    + org.springframework.web.util.HtmlUtils.htmlEscape(rememberMe.getName())
                                     + " whose value is: "
-                                    + rememberMe.getValue()
+                                    + org.springframework.web.util.HtmlUtils.htmlEscape(rememberMe.getValue())
                                     + "<br/>");
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/GrepSecurity/project-ignore-java-2/security/code-scanning/3628](https://github.com/GrepSecurity/project-ignore-java-2/security/code-scanning/3628)

To fix the cross-site scripting vulnerability, we need to ensure that any data written to the response is properly sanitized or encoded. In this case, we should use HTML encoding to sanitize the `rememberMe` cookie value and the `user` variable before writing them to the response.

We will use the `HtmlUtils.htmlEscape` method from the `org.springframework.web.util` package to encode these values. This method will convert special characters to their corresponding HTML entities, preventing XSS attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
